### PR TITLE
:green_heart: Fix MAC OS ci

### DIFF
--- a/test_package/conanfile.py
+++ b/test_package/conanfile.py
@@ -1,31 +1,18 @@
 from conan import ConanFile
 from conan.tools.build import cross_building
-from conan.tools.cmake import CMake, cmake_layout, CMakeToolchain
+from conan.tools.cmake import CMake, cmake_layout
 import os
 
 
 class TestPackageConan(ConanFile):
-    settings = "compiler", "build_type"
+    settings = "os", "arch", "compiler", "build_type"
     generators = "CMakeToolchain", "CMakeDeps", "VirtualRunEnv"
 
     def requirements(self):
         self.requires(self.tested_reference_str)
 
     def layout(self):
-        self.conf_info.define("tools.build:cxxflags", ["-Dtesting=1"])
-        self.conf_info.define(
-            "tools.cmake.cmaketoolchain:toolchain_file", [""])
         cmake_layout(self)
-
-    def package_info(self):
-        f = os.path.join(self.package_folder, "mytoolchain.cmake")
-        # Appending the value to any existing one
-        self.conf_info.append("tools.cmake.cmaketoolchain:user_toolchain", f)
-
-    def generate(self):
-        tc = CMakeToolchain(self)
-        tc.cmake_flags_init = ""
-        tc.generate()
 
     def build(self):
         cmake = CMake(self)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,8 +1,5 @@
 cmake_minimum_required(VERSION 3.15)
 
-set(CMAKE_C_COMPILER "gcc-11")
-set(CMAKE_CXX_COMPILER "g++-11")
-
 project(unit_test VERSION 0.0.1 LANGUAGES CXX)
 
 list(APPEND CMAKE_PREFIX_PATH ${CMAKE_BINARY_DIR})
@@ -48,7 +45,7 @@ target_link_options(${PROJECT_NAME} PRIVATE
   -fprofile-arcs
   -ftest-coverage)
 target_link_libraries(${PROJECT_NAME} PRIVATE
-  boost::ut
+  Boost::ut
   libhal::libhal
   libhal-util::libhal-util
 )

--- a/tests/conanfile.txt
+++ b/tests/conanfile.txt
@@ -1,5 +1,5 @@
 [requires]
-boost-ext-ut/1.1.8
+boost-ext-ut/1.1.9
 libhal/0.2.2
 libhal-util/0.2.4
 


### PR DESCRIPTION
The `conanfile.py` in `test_package/`, copied from librmd, was copied from source in the past without care as to its effects on the conan build system and has been replaced with the standard one used in libhal.