### PR TITLE
:construction_worker: Change job name to "ci"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
     - cron: '0 12 * * 0'
 
 jobs:
-  lint:
+  ci:
     uses: libhal/libhal/.github/workflows/checks.yml@main
     with:
       library: libhal-mock


### PR DESCRIPTION
Because lint is a silly name for the CI job.